### PR TITLE
Implemented reboot capability

### DIFF
--- a/lib/vagrant-tart/plugin.rb
+++ b/lib/vagrant-tart/plugin.rb
@@ -36,6 +36,11 @@ module VagrantPlugins
         SyncedFolder
       end
 
+      guest_capability "darwin", "reboot" do
+        require_relative "reboot"
+        Cap::Reboot
+      end
+
       # Register the custom VNC command.
       command("vnc", primary: false) do
         require_relative "command/vnc"

--- a/lib/vagrant-tart/reboot.rb
+++ b/lib/vagrant-tart/reboot.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Cap
+  # This class handles the reboot functionality
+  class Reboot
+    def self.reboot(machine)
+      machine.ui.info("Rebooting the guest machine...")
+      machine.communicate.execute("sudo shutdown -r now")
+    rescue Vagrant::Errors::VagrantError => e
+      machine.ui.error("Failed to reboot: #{e.message}")
+    end
+  end
+end


### PR DESCRIPTION
The users can now reboot the guest from within the Vagrantfile using the shell provisioner and setting reboot: true.

For example, during my efforts to make my macos guest compatible with usual Vagrant guest configuration (adding a /vagrant mountpoint on root filesystem), I need to perform a reboot of the Guest. This capability is available in other Vagrant plugins (built-in providers and third-party providers), but is missing from Vagrant-Tart plugin.

After this patch, adding `reboot: true` to a shell provisioner in `Vagrantfile` is now sufficient to perform the guest reboot. Here's a snippet of a session I now regularly see:

`Vagrantfile` contents:
```
  ...
  config.vm.provision "shell",                inline: "echo vagrant | sudo tee -a /etc/synthetic.conf >/dev/null"
  config.vm.provision "shell", reboot: true,  inline: "echo Rebooting the VM to mount project directory at /vagrant"
  ...
```

The above configuration results in `vagrant-tart` to perform a reboot of the guest macos:

```
    ...
    default: Key inserted! Disconnecting and reconnecting using new SSH key...
==> default: Machine booted and ready!
==> default: Running provisioner: shell...
    default: Running: inline script
==> default: Running provisioner: shell...
    default: Running: inline script
    default: Rebooting the VM to mount project directory at /vagrant
==> default: Rebooting the guest machine...
==> default: Running provisioner: shell...
    default: Running: inline script
    ...
```