### PR TITLE
Automatically generate VirtIO tag when one is not provided

### DIFF
--- a/lib/vagrant-tart/cap/mount_options.rb
+++ b/lib/vagrant-tart/cap/mount_options.rb
@@ -54,7 +54,7 @@ module VagrantPlugins
         end
 
         def self.mount_name(_machine, name, _data)
-          name.gsub(%r{[\s/\\]}, "_").sub(/^_/, "")
+          Digest::MD5.hexdigest(name)
         end
       end
     end

--- a/lib/vagrant-tart/cap/mount_options.rb
+++ b/lib/vagrant-tart/cap/mount_options.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+require_relative "../util/unix_mount_helpers"
+
+module VagrantPlugins
+  module Tart
+    module Cap
+      # Capability for mount options
+      module MountOptions
+        extend VagrantPlugins::SyncedFolder::UnixMountHelpers
+
+        # Mount type for VirtFS
+        TART_MOUNT_TYPE = "virtiofs"
+
+        # Returns mount options for a utm synced folder
+        #
+        # @param [Machine] machine
+        # @param [String] name of mount
+        # @param [String] path of mount on guest
+        # @param [Hash] hash of mount options
+        def self.mount_options(machine, _name, guest_path, options)
+          mount_options = options.fetch(:mount_options, [])
+          detected_ids = detect_owner_group_ids(machine, guest_path, mount_options, options)
+          mount_uid = detected_ids[:uid]
+          mount_gid = detected_ids[:gid]
+
+          # virtiofs mount options
+          mount_options << "_netdev"
+          mount_options << "nofail"
+
+          mount_options = mount_options.join(",")
+          [mount_options, mount_uid, mount_gid]
+        end
+
+        def self.mount_type(_machine)
+          TART_MOUNT_TYPE
+        end
+
+        def self.mount_name(_machine, name, _data)
+          name.gsub(%r{[\s/\\]}, "_").sub(/^_/, "")
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-tart/cap/mount_options.rb
+++ b/lib/vagrant-tart/cap/mount_options.rb
@@ -10,6 +10,7 @@ module VagrantPlugins
     module Cap
       # Capability for mount options
       module MountOptions
+        extend Vagrant::Util::GuestInspection::Linux
         extend VagrantPlugins::SyncedFolder::UnixMountHelpers
 
         # Mount type for VirtFS
@@ -22,13 +23,26 @@ module VagrantPlugins
         # @param [String] path of mount on guest
         # @param [Hash] hash of mount options
         def self.mount_options(machine, _name, guest_path, options)
+          comm = machine.communicate
           mount_options = options.fetch(:mount_options, [])
           detected_ids = detect_owner_group_ids(machine, guest_path, mount_options, options)
           mount_uid = detected_ids[:uid]
           mount_gid = detected_ids[:gid]
 
+          # Remove non-filesystem related mount options
+          mount_options = mount_options.reject { |opt| opt.include?("tag=") || opt.include?("mode=") }
+
           # virtiofs mount options
-          mount_options << "_netdev"
+
+          # For operating systems using systemd, we need to specify automounting and running prior-to remove filesystems being mounted
+          # This mimics the behaviour of _netdev in standard systems
+          if systemd?(comm)
+            mount_options << "x-systemd.automount"
+            mount_options << "x-systemd.before=remote-fs.target"
+          else
+            mount_options << "_netdev"
+          end
+
           mount_options << "nofail"
 
           mount_options = mount_options.join(",")

--- a/lib/vagrant-tart/cap/mount_options.rb
+++ b/lib/vagrant-tart/cap/mount_options.rb
@@ -34,7 +34,8 @@ module VagrantPlugins
 
           # virtiofs mount options
 
-          # For operating systems using systemd, we need to specify automounting and running prior-to remove filesystems being mounted
+          # For operating systems using systemd, we need to specify automounting
+          # and running prior-to remove filesystems being mounted
           # This mimics the behaviour of _netdev in standard systems
           if systemd?(comm)
             mount_options << "x-systemd.automount"
@@ -53,8 +54,14 @@ module VagrantPlugins
           TART_MOUNT_TYPE
         end
 
-        def self.mount_name(_machine, name, _data)
-          Digest::MD5.hexdigest(name)
+        def self.mount_name(_machine, name, data)
+          mount_options = data.fetch(:mount_options, [])
+
+          tag = mount_options.find { |option| option.start_with?("tag=") }
+                             &.split("=", 2)
+                             &.last
+
+          tag || Digest::MD5.hexdigest(name)
         end
       end
     end

--- a/lib/vagrant-tart/model/tart_disk.rb
+++ b/lib/vagrant-tart/model/tart_disk.rb
@@ -58,18 +58,18 @@ module VagrantPlugins
         private
 
         # Parse the mount options.
-        def parse_mount_options(mount_options)
+        def parse_mount_options(mount_options) # rubocop:disable Metrics/PerceivedComplexity
           # Mode option
           mode = mount_options.find { |option| option.start_with?("mode=") }
-          @mode = mode.split("=")[1] if mode
+                              &.split("=", 2)
+                              &.last
+          @mode = mode || "rw"
 
           # Tag option
           tag = mount_options.find { |option| option.start_with?("tag=") }
-          @tag = if tag
-                   tag.split("=")[1]
-                 else
-                   AUTO_MOUNT
-                 end
+                             &.split("=", 2)
+                             &.last
+          @tag = tag || Digest::MD5.hexdigest(@guest_path)
         end
       end
     end

--- a/lib/vagrant-tart/plugin.rb
+++ b/lib/vagrant-tart/plugin.rb
@@ -36,6 +36,21 @@ module VagrantPlugins
         SyncedFolder
       end
 
+      synced_folder_capability(:tart, "mount_options") do
+        require_relative "cap/mount_options"
+        Cap::MountOptions
+      end
+
+      synced_folder_capability(:tart, "mount_type") do
+        require_relative "cap/mount_options"
+        Cap::MountOptions
+      end
+
+      synced_folder_capability(:tart, "mount_name") do
+        require_relative "cap/mount_options"
+        Cap::MountOptions
+      end
+
       # Register the guest capabilities.
       guest_capability(:darwin, :reboot) do
         require_relative "cap/reboot"

--- a/lib/vagrant-tart/util/unix_mount_helpers.rb
+++ b/lib/vagrant-tart/util/unix_mount_helpers.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+# Copied from vagrant/plugins/synced_folder/unix_mount_helpers.rb
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+require "shellwords"
+require "vagrant/util/retryable"
+
+module VagrantPlugins
+  module SyncedFolder
+    # Contains helper methods for mounting folders on Unix-based systems.
+    module UnixMountHelpers # rubocop:disable Metrics/ModuleLength
+      def self.extended(klass)
+        unless klass.class_variable_defined?(:@@logger)
+          klass.class_variable_set(:@@logger, Log4r::Logger.new(klass.name.downcase)) # rubocop:disable Style/ClassVars
+        end
+        klass.extend Vagrant::Util::Retryable
+      end
+
+      def detect_owner_group_ids(machine, guest_path, mount_options, options) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/MethodLength,Metrics/PerceivedComplexity
+        mount_uid = find_mount_options_id("uid", mount_options)
+        mount_gid = find_mount_options_id("gid", mount_options)
+
+        if mount_uid.nil?
+          if options[:owner].to_i.to_s == options[:owner].to_s
+            mount_uid = options[:owner]
+            class_variable_get(:@@logger).debug("Owner user ID (provided): #{mount_uid}")
+          else
+            output = { stdout: String.new, stderr: String.new } # Ensure strings are not frozen
+            uid_command = "id -u #{options[:owner]}"
+            machine.communicate.execute(uid_command,
+                                        error_class: Vagrant::Errors::VirtualBoxMountFailed,
+                                        error_key: :virtualbox_mount_failed,
+                                        command: uid_command,
+                                        output: output[:stderr]) { |type, data| output[type] << data if output[type] }
+            mount_uid = output[:stdout].chomp
+            class_variable_get(:@@logger).debug("Owner user ID (lookup): #{options[:owner]} -> #{mount_uid}")
+          end
+        else
+          machine.ui.warn "Detected mount owner ID within mount options. (uid: #{mount_uid} guestpath: #{guest_path})"
+        end
+
+        if mount_gid.nil?
+          if options[:group].to_i.to_s == options[:group].to_s
+            mount_gid = options[:group]
+            class_variable_get(:@@logger).debug("Owner group ID (provided): #{mount_gid}")
+          else
+            begin
+              { stdout: String.new, stderr: String.new } # Ensure strings are not frozen
+              gid_command = "getent group #{options[:group]}"
+              machine.communicate.execute(gid_command,
+                                          error_class: Vagrant::Errors::VirtualBoxMountFailed,
+                                          error_key: :virtualbox_mount_failed,
+                                          command: gid_command,
+                                          output: output[:stderr]) { |type, data| output[type] << data if output[type] }
+              mount_gid = output[:stdout].split(":").at(2).to_s.chomp
+              class_variable_get(:@@logger).debug("Owner group ID (lookup): #{options[:group]} -> #{mount_gid}")
+            rescue Vagrant::Errors::VirtualBoxMountFailed
+              if options[:owner] == options[:group] # rubocop:disable Metrics/BlockNesting
+                class_variable_get(:@@logger).debug("Failed to locate group `#{options[:group]}`. Group name matches owner. Fetching effective group ID.") # rubocop:disable Layout/LineLength
+                output = { stdout: String.new }
+                result = machine.communicate.execute("id -g #{options[:owner]}",
+                                                     error_check: false) do |type, data|
+                  output[type] << data if output[type] # rubocop:disable Metrics/BlockNesting
+                end
+                mount_gid = output[:stdout].chomp if result.zero? # rubocop:disable Metrics/BlockNesting
+                class_variable_get(:@@logger).debug("Owner group ID (effective): #{mount_gid}")
+              end
+              raise unless mount_gid
+            end
+          end
+        else
+          machine.ui.warn "Detected mount group ID within mount options. (gid: #{mount_gid} guestpath: #{guest_path})"
+        end
+        { gid: mount_gid, uid: mount_uid }
+      end
+
+      def find_mount_options_id(id_name, mount_options) # rubocop:disable Metrics/AbcSize
+        id_line = mount_options.detect { |line| line.include?("#{id_name}=") }
+        if id_line
+          match = id_line.match(/,?#{Regexp.escape(id_name)}=(?<option_id>\d+),?/)
+          found_id = match["option_id"]
+          updated_id_line = [
+            match.pre_match,
+            match.post_match
+          ].find_all { |string| !string.empty? }.join(",")
+          if updated_id_line.empty?
+            mount_options.delete(id_line)
+          else
+            idx = mount_options.index(id_line)
+            mount_options.delete(idx)
+            mount_options.insert(idx, updated_id_line)
+          end
+        end
+        found_id
+      end
+
+      def emit_upstart_notification(machine, guest_path)
+        # Emit an upstart event if we can
+        machine.communicate.sudo <<-NOTIFICATION.gsub(/^ {12}/, "")
+            if test -x /sbin/initctl && command -v /sbin/init && /sbin/init 2>/dev/null --version | grep upstart; then
+              /sbin/initctl emit --no-wait vagrant-mounted MOUNTPOINT=#{guest_path}
+            fi
+        NOTIFICATION
+      end
+
+      def merge_mount_options(base, overrides) # rubocop:disable Metrics/AbcSize
+        base = base.join(",").split(",")
+        overrides = overrides.join(",").split(",")
+        b_kv = Hash[base.map { |item| item.split("=", 2) }]
+        o_kv = Hash[overrides.map { |item| item.split("=", 2) }]
+        merged = {}.tap do |opts|
+          (b_kv.keys + o_kv.keys).uniq.each do |key|
+            opts[key] = o_kv.fetch(key, b_kv[key])
+          end
+        end
+        merged.map do |key, value|
+          [key, value].compact.join("=")
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-tart/util/unix_mount_helpers.rb
+++ b/lib/vagrant-tart/util/unix_mount_helpers.rb
@@ -10,7 +10,7 @@ require "vagrant/util/retryable"
 module VagrantPlugins
   module SyncedFolder
     # Contains helper methods for mounting folders on Unix-based systems.
-    module UnixMountHelpers # rubocop:disable Metrics/ModuleLength
+    module UnixMountHelpers
       def self.extended(klass)
         unless klass.class_variable_defined?(:@@logger)
           klass.class_variable_set(:@@logger, Log4r::Logger.new(klass.name.downcase)) # rubocop:disable Style/ClassVars
@@ -76,7 +76,7 @@ module VagrantPlugins
         { gid: mount_gid, uid: mount_uid }
       end
 
-      def find_mount_options_id(id_name, mount_options) # rubocop:disable Metrics/AbcSize
+      def find_mount_options_id(id_name, mount_options)
         id_line = mount_options.detect { |line| line.include?("#{id_name}=") }
         if id_line
           match = id_line.match(/,?#{Regexp.escape(id_name)}=(?<option_id>\d+),?/)
@@ -105,11 +105,11 @@ module VagrantPlugins
         NOTIFICATION
       end
 
-      def merge_mount_options(base, overrides) # rubocop:disable Metrics/AbcSize
+      def merge_mount_options(base, overrides)
         base = base.join(",").split(",")
         overrides = overrides.join(",").split(",")
-        b_kv = Hash[base.map { |item| item.split("=", 2) }]
-        o_kv = Hash[overrides.map { |item| item.split("=", 2) }]
+        b_kv = base.to_h { |item| item.split("=", 2) }
+        o_kv = overrides.to_h { |item| item.split("=", 2) }
         merged = {}.tap do |opts|
           (b_kv.keys + o_kv.keys).uniq.each do |key|
             opts[key] = o_kv.fetch(key, b_kv[key])

--- a/spec/vagrant_plugins/tart/model/tart_disk_spec.rb
+++ b/spec/vagrant_plugins/tart/model/tart_disk_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe VagrantPlugins::Tart::Model::TartDisk do
     it "creates an auto-mounted disk at the root of /Volumes/My Shared Files" do
       data = {
         hostpath: "/Users/tart",
-        guestpath: "/Volumes/My Shared Files"
+        guestpath: "/Volumes/My Shared Files",
+        mount_options: ["tag=com.apple.virtio-fs.automount"]
       }
       disk = described_class.new(data)
       expect(disk.to_tart_disk).to eq("/Users/tart:tag=com.apple.virtio-fs.automount")
@@ -14,10 +15,31 @@ RSpec.describe VagrantPlugins::Tart::Model::TartDisk do
     it "creates an auto-mounted disk at the root of /Volumes/My Shared Files/tart" do
       data = {
         hostpath: "/Users/tart",
-        guestpath: "/Volumes/My Shared Files/tart"
+        guestpath: "/Volumes/My Shared Files/tart",
+        mount_options: ["tag=com.apple.virtio-fs.automount"]
       }
       disk = described_class.new(data)
       expect(disk.to_tart_disk).to eq("tart:/Users/tart:tag=com.apple.virtio-fs.automount")
+    end
+
+    it "creates a disk with the specifed tag and mode" do
+      data = {
+        hostpath: "/Users/tart",
+        guestpath: "/vagrant/tart",
+        mount_options: ["mode=rw", "tag=vagrant"]
+      }
+      disk = described_class.new(data)
+      expect(disk.to_tart_disk).to eq("/Users/tart:tag=vagrant")
+    end
+
+    it "creates a disk with an automatically generated (md5) tag when none is provided" do
+      data = {
+        hostpath: "/Users/tart",
+        guestpath: "/vagrant/tart"
+      }
+      disk = described_class.new(data)
+      tag = Digest::MD5.hexdigest(data[:guestpath])
+      expect(disk.to_tart_disk).to eq("/Users/tart:tag=#{tag}")
     end
 
     it "creates a read-only tag-mounted disk" do


### PR DESCRIPTION
This PR adds the the following capabilities:
 - Automatically generating a VirtIO mount tag when one is not provided as a mount option.
 - Automatically persisting mounts into the guest machine's fstab (if available).

Due to the restriction of 36 characters on VirtIO tags, I generate an MD5 hash of the guest path which is guaranteed to be 32 characters and be deterministic based on the input.

Unfortunately this is not compatible with defaulting to "com.apple.virtio-fs.automount" as the tag. My personal take away on this is most people use Vagrant to explicitly mount a host folder to a guest folder, however this may be different for people automating macOS.


Some additional things that can be done to this:
 - [ ] Call the mount name capability rather than rewriting the same code.


Fixes #69 