### PR TITLE
Fix provisioning occurring before synced folders are fully mounted

### DIFF
--- a/lib/vagrant-tart/action.rb
+++ b/lib/vagrant-tart/action.rb
@@ -22,6 +22,7 @@ module VagrantPlugins
       autoload :StopInstance, action_root.join("stop_instance")
       autoload :SuspendInstance, action_root.join("suspend_instance")
       autoload :VNCConnect, action_root.join("vnc_connect")
+      autoload :MessageWillNotDestroy, action_root.join("message_will_not_destroy")
 
       # Vargrant action "destroy".
       def self.action_destroy
@@ -189,11 +190,11 @@ module VagrantPlugins
       # Starts the virtual machine.
       def self.action_start
         Vagrant::Action::Builder.new.tap do |b|
+          b.use Provision
           b.use SyncedFolderCleanup
           b.use SyncedFolders
           b.use StartInstance
           b.use WaitForCommunicator
-          b.use Provision
         end
       end
     end

--- a/lib/vagrant-tart/action.rb
+++ b/lib/vagrant-tart/action.rb
@@ -193,6 +193,7 @@ module VagrantPlugins
           b.use Provision
           b.use SyncedFolderCleanup
           b.use SyncedFolders
+          b.use SetHostname
           b.use StartInstance
           b.use WaitForCommunicator
         end

--- a/lib/vagrant-tart/action.rb
+++ b/lib/vagrant-tart/action.rb
@@ -24,7 +24,7 @@ module VagrantPlugins
       autoload :VNCConnect, action_root.join("vnc_connect")
       autoload :MessageWillNotDestroy, action_root.join("message_will_not_destroy")
 
-      # Vargrant action "destroy".
+      # Vagrant action "destroy".
       def self.action_destroy
         Vagrant::Action::Builder.new.tap do |b|
           b.use ConfigValidate

--- a/lib/vagrant-tart/action/message_will_not_destroy.rb
+++ b/lib/vagrant-tart/action/message_will_not_destroy.rb
@@ -1,0 +1,20 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+module VagrantPlugins
+  module Tart
+    module Action
+      class MessageWillNotDestroy
+        def initialize(app, env)
+          @app = app
+        end
+
+        def call(env)
+          env[:ui].info I18n.t("vagrant.commands.destroy.will_not_destroy",
+                              name: env[:machine].name)
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-tart/action/message_will_not_destroy.rb
+++ b/lib/vagrant-tart/action/message_will_not_destroy.rb
@@ -15,7 +15,7 @@ module VagrantPlugins
 
         def call(env)
           env[:ui].info I18n.t("vagrant.commands.destroy.will_not_destroy",
-                              name: env[:machine].name)
+                               name: env[:machine].name)
           @app.call(env)
         end
       end

--- a/lib/vagrant-tart/action/message_will_not_destroy.rb
+++ b/lib/vagrant-tart/action/message_will_not_destroy.rb
@@ -1,11 +1,15 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
+# frozen_string_literal: true
+
+require "i18n"
 
 module VagrantPlugins
   module Tart
     module Action
+      # Action block to inform the user that the machine will not be destroyed.
       class MessageWillNotDestroy
-        def initialize(app, env)
+        def initialize(app, _env)
           @app = app
         end
 


### PR DESCRIPTION
Despite the way it seems, the builtin provision action should go before booting the VM as it internally waits until the VM is booted to continue[1], as does SyncedFolders[2].

This means you need to order the actions as: Provision -> SynecedFolders -> Boot, as Provision waits for Synced Folders, then Synced Folders waits for boot. 

With the previous setup this resolved as Boot -> Provision -> SyncedFolders and now this resolves as Boot -> SyncedFolders -> Provision, which correctly allows usage of synced folders during provisioning.

Additionally I've fixed two other issues:
- One issue where the VM will not be destroyed message that appears when declining to destroy an active VM displays an error instead.
- One issue where the Hostname of the VM is not updated based on the Vagrantfile configuration.


Fixes #70 

[1] https://github.com/hashicorp/vagrant/blob/e1c22285d2d650277990ca1a1c47ad8a1eb98eb9/lib/vagrant/action/builtin/provision.rb#L83
[2] https://github.com/hashicorp/vagrant/blob/e1c22285d2d650277990ca1a1c47ad8a1eb98eb9/lib/vagrant/action/builtin/synced_folders.rb#L89