### PR TITLE
Allow Agent IP Resolver method

### DIFF
--- a/lib/vagrant-tart/config.rb
+++ b/lib/vagrant-tart/config.rb
@@ -148,8 +148,8 @@ module VagrantPlugins
         # Check that the VNC and VNC experimental flags are not both true
         errors << I18n.t("vagrant_tart.config.vnc_exclusive") if @vnc == true && @vnc_experimental == true
 
-        # Check that the IP resolver is a valid string (either 'dhcp' or 'arp')
-        errors << I18n.t("vagrant_tart.config.ip_resolver_invalid") unless %w[dhcp arp].include? @ip_resolver
+        # Check that the IP resolver is a valid string (either 'dhcp', 'arp' or 'agent')
+        errors << I18n.t("vagrant_tart.config.ip_resolver_invalid") unless %w[dhcp arp agent].include? @ip_resolver
 
         # Check that the extra run arguments is an array of strings
         errors << I18n.t("vagrant_tart.config.extra_run_args_invalid") unless @extra_run_args.is_a? Array

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -17,6 +17,8 @@ en:
         Configuration must specify a valid GUI setting (true or false)
       image_required: |-
         Configuration must specify an image
+      ip_resolver_invalid: |-
+        Configuration must specify a valid IP resolver setting (dhcp, arp, or agent)
       ip_resolver_arp_invalid: |-
         Configuration must specify a valid IP resolver ARP setting (true or false)
       memory_invalid: |-


### PR DESCRIPTION
If the Tart Guest Agent is installed in the provided image then you are able to use the Agent Resolver to get the IP address of the VM.

I've found this more reliable in most situations over DHCP or ARP for Ubuntu linux VMs. 