### PR TITLE
Fix ocassional crash when reloading machine

### DIFF
--- a/lib/vagrant-tart/action.rb
+++ b/lib/vagrant-tart/action.rb
@@ -55,7 +55,7 @@ module VagrantPlugins
 
             b1.use Call, GracefulHalt, :stopped, :running do |env2, b2|
               if !env2[:result]
-                b1.use StopInstance
+                b2.use StopInstance
               end
             end
           end

--- a/lib/vagrant-tart/action.rb
+++ b/lib/vagrant-tart/action.rb
@@ -53,7 +53,11 @@ module VagrantPlugins
           b.use Call, IsState, :not_created do |env, b1|
             raise Errors::InstanceNotCreatedError if env[:result]
 
-            b1.use StopInstance
+            b1.use Call, GracefulHalt, :stopped, :running do |env2, b2|
+              if !env2[:result]
+                b1.use StopInstance
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
Sometimes the VM does not fully stop before reload calls start again. This can cause issues if you are using folder mounts, where the previous VM is still partially alive and claims the folders on the host machine.

Using the graceful halt action ensures the VM is in the correct state before moving on.